### PR TITLE
feat: allow customizing turn order

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Alternatively, instead of going through the interactive setup, you may also prov
     "settings": {
         "allow_termination": false,
         "use_markdown": true,
-        "initial_message": "*yawn* What do you want?"
+        "initial_message": "Why is the sky blue?",
+        "turn_order": "vote"
     }
 }
 ```
@@ -101,12 +102,19 @@ Optional parameters:
   - Higher values increase creativity
 - `ctx_size` (default: 2048): Maximum context length for the conversation
 
+Additionally, agent names must be unique.
+
 #### Conversation Settings
 
 The `settings` section controls overall conversation behavior:
-- `allow_termination` (default: `false`): Permit agents to end the conversation
-- `use_markdown` (default: `false`): Enable Markdown text formatting
-- `initial_message` (default: `null`): Optional starting prompt for the conversation
+- `allow_termination` (`boolean`, default: `false`): Permit agents to end the conversation
+- `use_markdown` (`boolean`, default: `false`): Enable Markdown text formatting
+- `initial_message` (`string | null`, default: `null`): Optional starting prompt for the conversation
+- `turn_order` (`"round_robin" | "random" | "moderator" | "vote"`, default: `"round_robin"`): Strategy for agent turn order
+  - `"round_robin"`: Agents are cycled through in order
+  - `"random"`: An agent other than the current one is randomly chosen
+  - `"moderator"`: A special moderator agent is designated to choose which agent speaks next. You may specify the moderator agent manually with the optional `moderator` key. If moderator isn't manually specified, one is created by the program instead based on other configuration options. Note that this method might be quite slow.
+  - `"vote"`: All agents are made to vote for an agent except the current one and themselves. Of the agents with the most amount of votes, one is randomly chosen. This is the slowest method of determining turn order.
 
 You can take a look at the [JSON configuration schema](schema.json) for more details.
 

--- a/schema.json
+++ b/schema.json
@@ -72,6 +72,30 @@
                     "default": null,
                     "description": "Initial message to start the conversation",
                     "title": "Initial Message"
+                },
+                "turn_order": {
+                    "default": "round_robin",
+                    "description": "Strategy for selecting the next agent",
+                    "enum": [
+                        "round_robin",
+                        "random",
+                        "moderator",
+                        "vote"
+                    ],
+                    "title": "Turn Order",
+                    "type": "string"
+                },
+                "moderator": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AgentConfig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "Configuration for the moderator agent (if using \"moderator\" turn order)"
                 }
             },
             "title": "ConversationSettings",


### PR DESCRIPTION
Previously, it wasn't possible to customize the order in which agents spoke. Instead the conversation manager just cycled through the agents in order, leading to a linear, often boring conversation flow.

This PR adds a new `turn_order` setting, which can be set to use one of the following strategies:
- "round_robin" (default): Cycle through the agents in order
- "random": Pick the next agent randomly
- "moderator": Have a dedicated Moderator agent which decides which agent will respond next.
- "vote": Allow all agents to vote on which agent responds next, the one with the most votes will respond. In case of a tie, the winner is picked randomly.

These new turn order strategies will allow spicing up the conversation flow and add variety.
